### PR TITLE
Add schematic_trace_id and source_trace_id to schematic_net_label if available when inferring net labels

### DIFF
--- a/lib/generateImplicitNetLabels.ts
+++ b/lib/generateImplicitNetLabels.ts
@@ -35,6 +35,9 @@ export const generateImplicitNetLabels = (
     const srcTrace = db.source_trace
       .list()
       .find((st) => st.connected_source_port_ids?.includes(sp.source_port_id))
+    const schTrace = db.schematic_trace.getWhere({
+      source_trace_id: srcTrace?.source_trace_id,
+    })
 
     const schematic_net_label_id = `netlabel_for_${sp.schematic_port_id}`
 
@@ -44,6 +47,7 @@ export const generateImplicitNetLabels = (
       text: srcNet.name,
       source_net_id: srcNet.source_net_id,
       source_trace_id: srcTrace?.source_trace_id,
+      schematic_trace_id: schTrace?.schematic_trace_id,
       anchor_position: { ...sp.center },
       center: { ...sp.center },
       anchor_side: oppositeSide(sp.facing_direction ?? "right"),


### PR DESCRIPTION
- **add source_trace_id if found**
- **add source_trace_id and schematic_trace_id if available**
