### PR TITLE
Add dist directory to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "main": "dist/index.js",
   "version": "0.0.13",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "start": "vite",
     "vercel-build": "vite build",


### PR DESCRIPTION
## Summary
- include the built dist directory in the package.json files array so it is published

## Testing
- `bunx tsc --noEmit` *(fails: existing type errors in lib/*)*
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68e1f4d2c058832eb6e84c6e2e53df78